### PR TITLE
fix: Clean up the commit messages before calculating the next version

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -39,7 +39,7 @@ impl<'a> Release<'a> {
 			.next(
 				self.commits
 					.iter()
-					.map(|commit| commit.message.to_string())
+					.map(|commit| commit.message.trim_end().to_string())
 					.collect::<Vec<String>>(),
 			)
 			.to_string();
@@ -70,6 +70,7 @@ mod test {
 			("1.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
 			("1.0.1", vec!["fix: add xyz", "fix: aaaaaa"]),
 			("2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ("2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
 		] {
 			let release = Release {
 				version:   None,


### PR DESCRIPTION
When the commit message ends with a '\n', then it is not considered a valid conventional commit. That's why the message must be cleaned up.

<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

Add trim_end() for cleanup

## Motivation and Context

Wrong next version when using the bumped-version parameter. The 'git commit' command creates a '\n' at the end of the line.

## How Has This Been Tested?

Linux/macos, git cli command.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
